### PR TITLE
Add SwiftUI support

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0ACFC8ED2DD550EB005549F3 /* SwiftUIDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ACFC8EC2DD550EB005549F3 /* SwiftUIDemoView.swift */; };
 		3713370629BBF51C00952B29 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3713370529BBF51C00952B29 /* AppDelegate.swift */; };
 		3713370829BBF51C00952B29 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3713370729BBF51C00952B29 /* SceneDelegate.swift */; };
 		3713370A29BBF51C00952B29 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3713370929BBF51C00952B29 /* ViewController.swift */; };
@@ -15,6 +16,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0ACFC8EC2DD550EB005549F3 /* SwiftUIDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIDemoView.swift; sourceTree = "<group>"; };
 		3713370229BBF51C00952B29 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3713370529BBF51C00952B29 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3713370729BBF51C00952B29 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -59,6 +61,7 @@
 				3713370529BBF51C00952B29 /* AppDelegate.swift */,
 				3713370729BBF51C00952B29 /* SceneDelegate.swift */,
 				3713370929BBF51C00952B29 /* ViewController.swift */,
+				0ACFC8EC2DD550EB005549F3 /* SwiftUIDemoView.swift */,
 				3713370E29BBF51E00952B29 /* Assets.xcassets */,
 				3713371329BBF51E00952B29 /* Info.plist */,
 			);
@@ -96,7 +99,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1420;
+				LastUpgradeCheck = 1630;
 				TargetAttributes = {
 					3713370129BBF51C00952B29 = {
 						CreatedOnToolsVersion = 14.2;
@@ -143,6 +146,7 @@
 				3713370A29BBF51C00952B29 /* ViewController.swift in Sources */,
 				3713370629BBF51C00952B29 /* AppDelegate.swift in Sources */,
 				3713370829BBF51C00952B29 /* SceneDelegate.swift in Sources */,
+				0ACFC8ED2DD550EB005549F3 /* SwiftUIDemoView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/Demo/SwiftUIDemoView.swift
+++ b/Demo/Demo/SwiftUIDemoView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+import ElegantEmojiPicker
+
+@available(iOS 14.0, *)
+struct SwiftUIDemoView: View {
+    @State private var selectedEmoji: Emoji? = nil
+    @State private var isEmojiPickerPresented: Bool = false
+
+    var body: some View {
+        VStack(spacing: 30) {
+            Text("SwiftUI Demo")
+                .font(.title)
+
+            if let emoji = selectedEmoji {
+                Text(emoji.emoji)
+                    .font(.system(size: 50))
+            } else {
+                Text("No emoji selected")
+                    .font(.headline)
+            }
+
+            Button(action: {
+                isEmojiPickerPresented.toggle()
+            }) {
+                Text(selectedEmoji == nil ? "Pick an Emoji" : "Change Emoji")
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+        }
+        .emojiPicker(
+            isPresented: $isEmojiPickerPresented,
+            selectedEmoji: $selectedEmoji,
+            configuration: ElegantConfiguration(
+                showRandom: false,
+                persistSkinTones: true),
+            localization: ElegantLocalization(
+                searchFieldPlaceholder: "SwiftUI Search")
+        )
+    }
+}
+
+@available(iOS 14.0, *)
+struct SwiftUIDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        SwiftUIDemoView()
+    }
+} 

--- a/Demo/Demo/SwiftUIDemoView.swift
+++ b/Demo/Demo/SwiftUIDemoView.swift
@@ -3,40 +3,39 @@ import ElegantEmojiPicker
 
 @available(iOS 14.0, *)
 struct SwiftUIDemoView: View {
-    @State private var selectedEmoji: Emoji? = nil
+    @State private var selectedEmoji: Emoji? = placeholderEmoji
     @State private var isEmojiPickerPresented: Bool = false
 
+    @State private var animate = true
+    
     var body: some View {
         VStack(spacing: 30) {
-            Text("SwiftUI Demo")
-                .font(.title)
+            Text(selectedEmoji?.emoji ?? "")
+                .font(.system(size: 50))
+                .scaleEffect(animate ? 1.0 : 0.1)
+                .animation(
+                    .interpolatingSpring(stiffness: 400, damping: 20),
+                    value: animate
+                )
+                .onChange(of: selectedEmoji) { _ in
+                    animate = false
+                    DispatchQueue.main.async {
+                        animate = true
+                    }
+                }
 
-            if let emoji = selectedEmoji {
-                Text(emoji.emoji)
-                    .font(.system(size: 50))
-            } else {
-                Text("No emoji selected")
-                    .font(.headline)
-            }
-
-            Button(action: {
+            Button("Select emoji") {
                 isEmojiPickerPresented.toggle()
-            }) {
-                Text(selectedEmoji == nil ? "Pick an Emoji" : "Change Emoji")
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
             }
+            .frame(width: 200, height: 40)
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(8)
         }
+        .navigationTitle(Text("Swift UI Demo"))
         .emojiPicker(
             isPresented: $isEmojiPickerPresented,
             selectedEmoji: $selectedEmoji,
-            configuration: ElegantConfiguration(
-                showRandom: false,
-                persistSkinTones: true),
-            localization: ElegantLocalization(
-                searchFieldPlaceholder: "SwiftUI Search")
         )
     }
 }
@@ -46,4 +45,6 @@ struct SwiftUIDemoView_Previews: PreviewProvider {
     static var previews: some View {
         SwiftUIDemoView()
     }
-} 
+}
+
+let placeholderEmoji: Emoji = Emoji(emoji: "😀", description: "", category: .SmileysAndEmotion, aliases: [], tags: [], supportsSkinTones: false, iOSVersion: "")

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import ElegantEmojiPicker
+import SwiftUI
 
 class ViewController: UIViewController {
      let emojiLabel: UILabel = {
@@ -27,18 +28,31 @@ class ViewController: UIViewController {
         return button
     }()
     
+    let swiftuiDemoButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("Show SwiftUI Demo", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.setTitleColor(.systemGray, for: .highlighted)
+        button.layer.cornerRadius = 8
+        button.backgroundColor = .systemGreen
+        return button
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.view.backgroundColor = .systemBackground
         
         emojiSelectionButton.addTarget(self, action: #selector(TappedEmojiSelection), for: .touchUpInside)
+        swiftuiDemoButton.addTarget(self, action: #selector(TappedSwiftUIDemo), for: .touchUpInside)
         
         self.view.translatesAutoresizingMaskIntoConstraints = false
         emojiLabel.translatesAutoresizingMaskIntoConstraints = false
         emojiSelectionButton.translatesAutoresizingMaskIntoConstraints = false
+        swiftuiDemoButton.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(emojiLabel)
         self.view.addSubview(emojiSelectionButton)
+        self.view.addSubview(swiftuiDemoButton)
         
         let lg = UILayoutGuide()
         self.view.addLayoutGuide(lg)
@@ -50,17 +64,33 @@ class ViewController: UIViewController {
             emojiSelectionButton.centerXAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerXAnchor),
             emojiSelectionButton.heightAnchor.constraint(equalToConstant: 40),
             
+            swiftuiDemoButton.topAnchor.constraint(equalTo: emojiSelectionButton.bottomAnchor, constant: 16),
+            swiftuiDemoButton.centerXAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerXAnchor),
+            swiftuiDemoButton.heightAnchor.constraint(equalToConstant: 40),
+            swiftuiDemoButton.widthAnchor.constraint(equalTo: emojiSelectionButton.widthAnchor, constant: 40),
+            
             lg.topAnchor.constraint(equalTo: emojiLabel.topAnchor),
-            lg.bottomAnchor.constraint(equalTo: emojiSelectionButton.bottomAnchor),
-            lg.leadingAnchor.constraint(equalTo: emojiSelectionButton.leadingAnchor),
-            lg.trailingAnchor.constraint(equalTo: emojiSelectionButton.trailingAnchor),
+            lg.bottomAnchor.constraint(equalTo: swiftuiDemoButton.bottomAnchor),
+            lg.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            lg.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             lg.centerYAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerYAnchor),
-            lg.widthAnchor.constraint(equalToConstant: 200)
         ])
     }
     
     @objc func TappedEmojiSelection () {
         self.present(ElegantEmojiPicker(delegate: self, sourceView: emojiSelectionButton), animated: true)
+    }
+    
+    @objc func TappedSwiftUIDemo () {
+        if #available(iOS 14.0, *) {
+            let swiftUIDemoView = SwiftUIDemoView()
+            let hostingController = UIHostingController(rootView: swiftUIDemoView)
+            self.present(hostingController, animated: true, completion: nil)
+        } else {
+            let alert = UIAlertController(title: "SwiftUI Not Available", message: "SwiftUI features require iOS 14 or later.", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(alert, animated: true)
+        }
     }
 }
 

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -63,14 +63,15 @@ class ViewController: UIViewController {
             emojiSelectionButton.topAnchor.constraint(equalTo: emojiLabel.bottomAnchor, constant: 32),
             emojiSelectionButton.centerXAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerXAnchor),
             emojiSelectionButton.heightAnchor.constraint(equalToConstant: 40),
+            emojiSelectionButton.widthAnchor.constraint(equalToConstant: 200),
             
-            swiftuiDemoButton.topAnchor.constraint(equalTo: emojiSelectionButton.bottomAnchor, constant: 16),
+            swiftuiDemoButton.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
             swiftuiDemoButton.centerXAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerXAnchor),
             swiftuiDemoButton.heightAnchor.constraint(equalToConstant: 40),
-            swiftuiDemoButton.widthAnchor.constraint(equalTo: emojiSelectionButton.widthAnchor, constant: 40),
+            swiftuiDemoButton.widthAnchor.constraint(equalToConstant: 200),
             
             lg.topAnchor.constraint(equalTo: emojiLabel.topAnchor),
-            lg.bottomAnchor.constraint(equalTo: swiftuiDemoButton.bottomAnchor),
+            lg.bottomAnchor.constraint(equalTo: emojiSelectionButton.bottomAnchor),
             lg.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
             lg.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             lg.centerYAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.centerYAnchor),
@@ -83,8 +84,7 @@ class ViewController: UIViewController {
     
     @objc func TappedSwiftUIDemo () {
         if #available(iOS 14.0, *) {
-            let swiftUIDemoView = SwiftUIDemoView()
-            let hostingController = UIHostingController(rootView: swiftUIDemoView)
+            let hostingController = UIHostingController(rootView: SwiftUIDemoView())
             self.present(hostingController, animated: true, completion: nil)
         } else {
             let alert = UIAlertController(title: "SwiftUI Not Available", message: "SwiftUI features require iOS 14 or later.", preferredStyle: .alert)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,44 @@ func emojiPicker(_ picker: ElegantEmojiPicker, didSelectEmoji emoji: Emoji?) {
 
 It is that easy. If simply offering emojis is all your soul desires, we are done. But if you are a more intricate type of coder and want more control, keep on readin'.
 
+### SwiftUI Usage (iOS 14+)
+
+For SwiftUI applications, you can use the `.emojiPicker` view modifier to present the emoji picker. You'll need two state variables: one to control the presentation of the picker and another to hold the selected emoji.
+
+```swift
+import SwiftUI
+import ElegantEmojiPicker
+
+struct MySwiftUIView: View {
+    @State private var isEmojiPickerPresented = false
+    @State private var selectedEmoji: Emoji? = nil
+
+    var body: some View {
+        VStack {
+            if let emoji = selectedEmoji {
+                Text(emoji.emoji)
+                    .font(.largeTitle)
+            } else {
+                Text("Tap to pick an emoji")
+            }
+
+            Button(selectedEmoji == nil ? "Pick Emoji" : "Change Emoji") {
+                isEmojiPickerPresented.toggle()
+            }
+        }
+        .emojiPicker(
+            isPresented: $isEmojiPickerPresented,
+            selectedEmoji: $selectedEmoji
+            // Optionally, pass configuration and localization:
+            // configuration: ElegantConfiguration(showRandom: false),
+            // localization: ElegantLocalization(searchFieldPlaceholder: "Find your emoji...")
+        )
+    }
+}
+```
+
+The `selectedEmoji` will be an optional `Emoji` object. It will be `nil` if the user dismisses the picker without making a selection or resets their choice (if the reset button is shown and used).
+
 ## 🎨 Configuration
 
 ### Showing or hiding features

--- a/README.md
+++ b/README.md
@@ -96,12 +96,7 @@ struct MySwiftUIView: View {
 
     var body: some View {
         VStack {
-            if let emoji = selectedEmoji {
-                Text(emoji.emoji)
-                    .font(.largeTitle)
-            } else {
-                Text("Tap to pick an emoji")
-            }
+            Text(selectedEmoji?.emoji ?? "No emoji selected")
 
             Button(selectedEmoji == nil ? "Pick Emoji" : "Change Emoji") {
                 isEmojiPickerPresented.toggle()
@@ -110,9 +105,9 @@ struct MySwiftUIView: View {
         .emojiPicker(
             isPresented: $isEmojiPickerPresented,
             selectedEmoji: $selectedEmoji
-            // Optionally, pass configuration and localization:
-            // configuration: ElegantConfiguration(showRandom: false),
-            // localization: ElegantLocalization(searchFieldPlaceholder: "Find your emoji...")
+            // detents: [.large] // Specify which presentation detents to use for the slide sheet (Optional)
+            // configuration: ElegantConfiguration(showRandom: false), // Pass configuration (Optional)
+            // localization: ElegantLocalization(searchFieldPlaceholder: "Find your emoji...") // Pass localization (Optional)
         )
     }
 }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Elegant Emoji Picker iOS version](https://img.shields.io/badge/iOS-13.0%2B-blue)
 ![Elegant Emoji Picker MacCatalyst version](https://img.shields.io/badge/MacCatalyst-13.0%2B-blue)
 ![Elegant Emoji Picker UIKit](https://img.shields.io/badge/Framework-UIKit-red)
+![Elegant Emoji Picker SwiftUI](https://img.shields.io/badge/Framework-SwiftUI-red)
 ![Elengat Emoji Picker Swift](https://img.shields.io/badge/Language-Swift-orange)
 ![Elegant Emoji Picker MIT License](https://img.shields.io/github/license/finalet/elegant-emoji-picker)
 ![Elengat Emoji Picker Contact](https://img.shields.io/badge/Contact-%40GrantOgany-darkgray?link=https://twitter.com/GrantOgany)

--- a/Sources/ElegantEmojiPicker+SwiftUI.swift
+++ b/Sources/ElegantEmojiPicker+SwiftUI.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+import UIKit
+
+@available(iOS 14.0, *)
+struct ElegantEmojiPickerRepresentable: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    @Binding var selectedEmoji: Emoji?
+    let configuration: ElegantConfiguration
+    let localization: ElegantLocalization
+
+    func makeUIViewController(context: Context) -> ElegantEmojiPicker {
+        let picker = ElegantEmojiPicker(
+            delegate: context.coordinator,
+            configuration: configuration,
+            localization: localization
+        )
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: ElegantEmojiPicker, context: Context) {
+        // Updates can be handled here if needed, for example, if configuration or localization could change
+        // while the picker is presented. For now, we assume they are set at initialization.
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, ElegantEmojiPickerDelegate, UIAdaptivePresentationControllerDelegate {
+        var parent: ElegantEmojiPickerRepresentable
+
+        init(_ parent: ElegantEmojiPickerRepresentable) {
+            self.parent = parent
+        }
+
+        // MARK: - ElegantEmojiPickerDelegate
+        func emojiPicker(_ picker: ElegantEmojiPicker, didSelectEmoji emoji: Emoji?) {
+            parent.selectedEmoji = emoji
+        }
+
+        // MARK: - UIAdaptivePresentationControllerDelegate
+        func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+            // Handle dismissal by swipe or other non-programmatic means
+            if parent.isPresented {
+                parent.isPresented = false
+            }
+        }
+        
+        // Optional delegate methods that we can leave to their default implementations for now
+        // or expose further if advanced customization is needed.
+        // func emojiPicker(_ picker: ElegantEmojiPicker, focusedSectionChanged to: Int, from: Int) {}
+        // func emojiPicker(_ picker: ElegantEmojiPicker, searchResultFor prompt: String, fromAvailable: [EmojiSection]) -> [Emoji] {
+        //     return ElegantEmojiPicker.getSearchResults(prompt, fromAvailable: fromAvailable)
+        // }
+        // func emojiPicker(_ picker: ElegantEmojiPicker, didStartPreview emoji: Emoji) {}
+        // func emojiPicker(_ picker: ElegantEmojiPicker, didChangePreview emoji: Emoji, from: Emoji) {}
+        // func emojiPicker(_ picker: ElegantEmojiPicker, didEndPreview emoji: Emoji) {}
+        // func emojiPickerDidStartSearching(_ picker: ElegantEmojiPicker) {}
+        // func emojiPickerDidEndSearching(_ picker: ElegantEmojiPicker) {}
+        // func emojiPickerShouldDismissAfterSelection (_ picker: ElegantEmojiPicker) -> Bool { return true }
+        // func emojiPicker (_ picker: ElegantEmojiPicker, loadEmojiSections withConfiguration: ElegantConfiguration, _ withLocalization: ElegantLocalization) -> [EmojiSection] {
+        //     return ElegantEmojiPicker.getDefaultEmojiSections(config: withConfiguration, localization: withLocalization)
+        // }
+    }
+}
+
+@available(iOS 14.0, *)
+struct EmojiPickerViewModifier: ViewModifier {
+    @Binding var isPresented: Bool
+    @Binding var selectedEmoji: Emoji?
+    var configuration: ElegantConfiguration = ElegantConfiguration()
+    var localization: ElegantLocalization = ElegantLocalization()
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(isPresented: $isPresented) {
+                ElegantEmojiPickerRepresentable(
+                    isPresented: $isPresented,
+                    selectedEmoji: $selectedEmoji,
+                    configuration: configuration,
+                    localization: localization
+                )
+                .ignoresSafeArea(.container, edges: .bottom)
+            }
+    }
+}
+
+@available(iOS 14.0, *)
+public extension View {
+    func emojiPicker(
+        isPresented: Binding<Bool>,
+        selectedEmoji: Binding<Emoji?>,
+        configuration: ElegantConfiguration = ElegantConfiguration(),
+        localization: ElegantLocalization = ElegantLocalization()
+    ) -> some View {
+        self.modifier(
+            EmojiPickerViewModifier(
+                isPresented: isPresented,
+                selectedEmoji: selectedEmoji,
+                configuration: configuration,
+                localization: localization
+            )
+        )
+    }
+} 

--- a/Sources/ElegantEmojiPicker+SwiftUI.swift
+++ b/Sources/ElegantEmojiPicker+SwiftUI.swift
@@ -68,6 +68,7 @@ struct ElegantEmojiPickerRepresentable: UIViewControllerRepresentable {
 struct EmojiPickerViewModifier: ViewModifier {
     @Binding var isPresented: Bool
     @Binding var selectedEmoji: Emoji?
+    var detents: Set<AvailablePresentationDetent> = [.medium, .large]
     var configuration: ElegantConfiguration = ElegantConfiguration()
     var localization: ElegantLocalization = ElegantLocalization()
 
@@ -81,6 +82,7 @@ struct EmojiPickerViewModifier: ViewModifier {
                     localization: localization
                 )
                 .ignoresSafeArea(.container, edges: .bottom)
+                .withPresentationDetents(detents)
             }
     }
 }
@@ -90,6 +92,7 @@ public extension View {
     func emojiPicker(
         isPresented: Binding<Bool>,
         selectedEmoji: Binding<Emoji?>,
+        detents: Set<AvailablePresentationDetent> = [.medium, .large],
         configuration: ElegantConfiguration = ElegantConfiguration(),
         localization: ElegantLocalization = ElegantLocalization()
     ) -> some View {
@@ -97,9 +100,55 @@ public extension View {
             EmojiPickerViewModifier(
                 isPresented: isPresented,
                 selectedEmoji: selectedEmoji,
+                detents: detents,
                 configuration: configuration,
                 localization: localization
             )
         )
     }
-} 
+}
+
+
+@available(iOS 14.0, *)
+struct PresentationDetendsModifier: ViewModifier {
+    let detents: Set<AvailablePresentationDetent>
+    
+    func body(content: Content) -> some View {
+        if #available(iOS 16.0, *) {
+            content
+                .presentationDetents(Set(detents.compactMap(\.systemDetent)))
+        } else {
+            content
+        }
+    }
+}
+
+@available(iOS 14.0, *)
+extension View {
+    func withPresentationDetents(_ detents: Set<AvailablePresentationDetent>) -> some View {
+        self.modifier(PresentationDetendsModifier(detents: detents))
+    }
+}
+
+
+@available(iOS 14.0, *)
+public enum AvailablePresentationDetent: Hashable {
+    case medium
+    case large
+    case fraction(CGFloat)
+    case height(CGFloat)
+    
+    @available(iOS 16.0, *)
+    var systemDetent: PresentationDetent {
+        switch self {
+        case .medium:
+            return .medium
+        case .large:
+            return .large
+        case .fraction(let value):
+            return .fraction(value)
+        case .height(let value):
+            return .height(value)
+        }
+    }
+}


### PR DESCRIPTION
Adds basic SwiftUI support (missing some delegate functionality present in the UIKit version). Updated README and Demo project to show example usage.

SwiftUI functionality requires iOS 14+ due to some feature availability, but I left the package requirement at iOS 13+ and all UIKit functionality will still work with iOS 13.