### PR TITLE
Adopt Codable for Emoji & Emoji Category

### DIFF
--- a/Sources/Definitions.swift
+++ b/Sources/Definitions.swift
@@ -10,13 +10,13 @@ import UIKit
 import CoreText
 
 /// Struct representing a single emoji
-public struct Emoji: Decodable, Equatable {
+public struct Emoji: Codable, Equatable {
     public let emoji: String
     public let description: String
     public let category: EmojiCategory
     public let aliases: [String]
     public let tags: [String]
-    public let supportsSkinTones: Bool
+    public let supportsSkinTones: Bool?
     public let iOSVersion: String
     
     /// Get a string representation of this emoji with another skin tone
@@ -25,7 +25,7 @@ public struct Emoji: Decodable, Equatable {
     public func emoji (_ withSkinTone: EmojiSkinTone?) -> String? {
         // Applying skin tones with Dan Wood's code: https://github.com/Remotionco/Emoji-Library-and-Utilities
         
-        if !supportsSkinTones { return nil }
+        if !(supportsSkinTones ?? false) { return nil }
         // If skin tone is nil, return the default yellow emoji
         guard let withSkinTone = withSkinTone else {
             if let unicode = emoji.unicodeScalars.first { return String(unicode) }
@@ -64,25 +64,14 @@ public struct Emoji: Decodable, Equatable {
         return string
     }
     
-    enum CodingKeys: CodingKey {
+    enum CodingKeys: String, CodingKey {
         case emoji
         case description
         case category
         case aliases
         case tags
-        case skin_tones
-        case ios_version
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.emoji = try container.decode(String.self, forKey: .emoji)
-        self.description = try container.decode(String.self, forKey: .description)
-        self.category = try container.decode(EmojiCategory.self, forKey: .category)
-        self.aliases = try container.decode([String].self, forKey: .aliases)
-        self.tags = try container.decode([String].self, forKey: .tags)
-        self.supportsSkinTones = try container.decodeIfPresent(Bool.self, forKey: .skin_tones) ?? false
-        self.iOSVersion = try container.decode(String.self, forKey: .ios_version)
+        case supportsSkinTones = "skin_tones"
+        case iOSVersion = "ios_version"
     }
     
     /// Create an instance of an emoji
@@ -108,7 +97,7 @@ public struct Emoji: Decodable, Equatable {
     /// - Parameter withSkinTone: new skin tone to use. If nil, creates a standard yellow emoji
     /// - Returns: new Emoji with the applied skin tone
     public func duplicate (_ withSkinTone: EmojiSkinTone?) -> Emoji {
-        return Emoji(emoji: self.emoji(withSkinTone) ?? emoji, description: description, category: category, aliases: aliases, tags: tags, supportsSkinTones: supportsSkinTones, iOSVersion: iOSVersion)
+        return Emoji(emoji: self.emoji(withSkinTone) ?? emoji, description: description, category: category, aliases: aliases, tags: tags, supportsSkinTones: supportsSkinTones ?? false, iOSVersion: iOSVersion)
     }
 }
 
@@ -138,7 +127,7 @@ public enum EmojiSkinTone: String, CaseIterable {
     case Dark = "🏿"
 }
 
-public enum EmojiCategory: String, CaseIterable, Decodable {
+public enum EmojiCategory: String, CaseIterable, Codable {
     case SmileysAndEmotion = "Smileys & Emotion"
     case PeopleAndBody = "People & Body"
     case AnimalsAndNature = "Animals & Nature"

--- a/Sources/ElegantEmojiPicker.swift
+++ b/Sources/ElegantEmojiPicker.swift
@@ -368,7 +368,7 @@ extension ElegantEmojiPicker: UIGestureRecognizerDelegate {
         }
         
         let location = sender.location(in: collectionView)
-        guard let indexPath = collectionView.indexPathForItem(at: location), let cell = collectionView.cellForItem(at: indexPath) as? EmojiCell, !(sender.state == .began && cell.emoji.supportsSkinTones && config.supportsSkinTones) else  {  return }
+        guard let indexPath = collectionView.indexPathForItem(at: location), let cell = collectionView.cellForItem(at: indexPath) as? EmojiCell, !(sender.state == .began && cell.emoji.supportsSkinTones ?? false && config.supportsSkinTones) else  {  return }
                 
         if sender.state == .began {
             ShowEmojiPreview(emoji: cell.emoji)
@@ -514,7 +514,7 @@ extension ElegantEmojiPicker {
     /// - Returns: Array of all emojis.
     static public func getAllEmoji () -> [Emoji] {
         let emojiData = (try? Data(contentsOf: Bundle.module.url(forResource: "Emoji Unicode 16.0", withExtension: "json")!))!
-        return try! JSONDecoder().decode([Emoji].self, from: emojiData)
+        return (try? JSONDecoder().decode([Emoji].self, from: emojiData)) ?? []
     }
     
     /// Returns an array of all available emojis categorized by section.
@@ -527,7 +527,7 @@ extension ElegantEmojiPicker {
         
         let persistedSkinTones = ElegantEmojiPicker.persistedSkinTones
         emojis = emojis.map({
-            if !$0.supportsSkinTones { return $0 }
+            if !($0.supportsSkinTones ?? false) { return $0 }
             
             if let persistedSkinToneStr = persistedSkinTones[$0.description], let persistedSkinTone = EmojiSkinTone(rawValue: persistedSkinToneStr) {
                 return $0.duplicate(persistedSkinTone)

--- a/Sources/Elements/EmojiCell.swift
+++ b/Sources/Elements/EmojiCell.swift
@@ -38,7 +38,7 @@ class EmojiCell: UICollectionViewCell {
     @objc func LongPress (_ sender: UILongPressGestureRecognizer) {
         guard let emojiPicker = emojiPicker else { return }
 
-        if !emojiPicker.config.supportsSkinTones || !emoji.supportsSkinTones { return }
+        if !emojiPicker.config.supportsSkinTones || !(emoji.supportsSkinTones ?? false) { return }
         
         if sender.state == .began {
             emojiPicker.ShowSkinToneSelector(self)


### PR DESCRIPTION
Edited the library to use the default implementations for Codable

The intent is once Emoji is marked as Codable, the structure is now storable using JSON encoding/decoding with ease.

- Edited CodingKeys to have the custom strings used for "skin_tones" & "ios_version" without breaking the Emoji struct's naming pattern
- Edited supportsSkinTones to be Optional Bool, as the key is missing on some Emoji's when loaded from the bundle.
- Edited Picker function getAllEmoji's to return an empty array instead of crashing from a try!